### PR TITLE
fixed indentation and included additional packages

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,10 +13,13 @@ dependencies:
     - dash-bootstrap-components
     - plotly
     - pandas
+    - flask
+    - hdbscan
+    - scikit-plot
     - numpy
     - matplotlib
     - jupyter-dash
     - scikit-learn
     - pip
-pip:
-    - dash-vega-components
+    - pip:
+        - dash-vega-components


### PR DESCRIPTION
The original yaml file has the pip mis-indented. This commit fixes that by adding the correct indentation to pip to make it fall under dependencies. Additionally, flask, scipy and hdbsacan have been added just in case.