### PR TITLE
Bargraph & Filters update #1 For M3

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,7 +74,7 @@ home_income_range_slider =  html.Label([
     tooltip={'placement': 'bottom', 'always_visible': False})
 ])
 
-beds_slider =  html.Label([
+beds_input =  html.Label([
     "Beds",
     html.Div([
         dcc.Input(
@@ -99,7 +99,7 @@ beds_slider =  html.Label([
 ])
 
 
-baths_slider =  html.Label([
+baths_input=  html.Label([
     "Baths",
     html.Div([
         dcc.Input(
@@ -156,8 +156,8 @@ app.layout = dbc.Container([
             dbc.Row([price_range_slider]),
             dbc.Row([price_per_square_footage_range_slider]),
             dbc.Row([home_income_range_slider]),
-            dbc.Row([beds_slider]),
-            dbc.Row([baths_slider]),
+            dbc.Row([beds_input]),
+            dbc.Row([baths_input]),
         ], md=2),
         # Second column is for --> Map, bar, and summary Stats
         dbc.Col([

--- a/src/app.py
+++ b/src/app.py
@@ -10,7 +10,7 @@ import pandas as pd
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
 
-df = pd.read_csv('../data/processed/processed_df.csv')  
+df = pd.read_csv('data/processed/processed_df.csv')  
 
 title = dbc.Row([dbc.Col(html.H1('Dreamhouse Real Estate Dashboard'), width=12)])
 

--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,7 @@ import pandas as pd
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
 
-df = pd.read_csv('/data/processed/processed_df.csv')  
+df = pd.read_csv('/data/processed/processed_df.csv')   
 
 title = dbc.Row([dbc.Col(html.H1('Dreamhouse Real Estate Dashboard'), width=12)])
 

--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,7 @@ import pandas as pd
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
 
-df = pd.read_csv('../data/processed/processed_df.csv')   
+df = pd.read_csv('/data/processed/processed_df.csv')   
 
 title = dbc.Row([dbc.Col(html.H1('Dreamhouse Real Estate Dashboard'), width=12)])
 
@@ -320,7 +320,7 @@ def update_city_bar_graph(state, city, square_footage_range, price_range, ppsf_r
     alphabet_colors = px.colors.qualitative.Alphabet
     Dark_colors = px.colors.qualitative.Dark24
     Vivid_colors = px.colors.qualitative.Vivid
-    combined_palette = Pastel_colors + alphabet_colors + Dark_colors + Vivid_colors
+    combined_palette = Pastel_colors + alphabet_colors + Dark_colors + Vivid_colors # Created our own color palette :)
     
     if not filtered_df.empty:
         avg_prices = filtered_df.groupby(groupby_col, as_index=False)['Price'].agg(['mean', 'count'])

--- a/src/app.py
+++ b/src/app.py
@@ -4,13 +4,12 @@ import dash_bootstrap_components as dbc
 from dash.dependencies import Input, Output
 import plotly.express as px
 import pandas as pd
-#from dash.exceptions import PreventUpdate
 
 # Initialize the Dash application
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
 
-df = pd.read_csv('data/processed/processed_df.csv')  
+df = pd.read_csv('/data/processed/processed_df.csv')  
 
 title = dbc.Row([dbc.Col(html.H1('Dreamhouse Real Estate Dashboard'), width=12)])
 
@@ -257,17 +256,15 @@ def select_state_on_map_click(clickData):
             return clicked_state_full
     raise dash.exceptions.PreventUpdate
 
-
-
 @app.callback(
     Output('city-dropdown', 'options'),
+    Output('city-dropdown', 'value'),
     Input('state-dropdown', 'value'))
 def set_cities_options(selected_state):
     if selected_state == 'All':
-        return [{'label': 'All', 'value': 'All'}] + [{'label': city, 'value': city} for city in df['City'].unique()]
+        return [{'label': 'All', 'value': 'All'}] + [{'label': city, 'value': city} for city in df['City'].unique()], 'All'
     else:
-        return [{'label': 'All', 'value': 'All'}] + [{'label': city, 'value': city} for city in df[df['State'] == selected_state]['City'].unique()]
-
+        return [{'label': 'All', 'value': 'All'}] + [{'label': city, 'value': city} for city in df[df['State'] == selected_state]['City'].unique()], 'All'
 
 @app.callback(
     Output('city-bar-graph', 'figure'),
@@ -625,8 +622,8 @@ def update_average_beds(state, city, square_footage_range, price_range, ppsf_ran
 #            [df['Price'].min(), df['Price'].max()],
 #            [round(df['Price per SqFt'].min(), 3), df['Price per SqFt'].max()],
 #            [df['Median Household Income'].min(), df['Median Household Income'].max()],
- #           df['Beds'].min(), df['Beds'].max(),
- #           df['Baths'].min(), df['Baths'].max())
+#            df['Beds'].min(), df['Beds'].max(),
+#            df['Baths'].min(), df['Baths'].max())
 
 if __name__ == '__main__':
     app.run_server(debug=False)

--- a/src/app.py
+++ b/src/app.py
@@ -4,6 +4,7 @@ import dash_bootstrap_components as dbc
 from dash.dependencies import Input, Output
 import plotly.express as px
 import pandas as pd
+#from dash.exceptions import PreventUpdate
 
 # Initialize the Dash application
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
@@ -20,7 +21,8 @@ state_dropdown = html.Label([
     options=[{'label': 'All', 'value': 'All'}] + [{'label': state, 'value': state} for state in df['State'].unique()],
     value='All',
     clearable=False
-    )
+    ),
+    html.Br()
 ])
 
 city_dropdown = html.Label([
@@ -30,7 +32,8 @@ city_dropdown = html.Label([
     options=[{'label': 'All', 'value': 'All'}],
     value='All',
     clearable=False,
-    )
+    ),
+    html.Br()
 ])
 
 square_footage_slider =  html.Label([
@@ -40,7 +43,8 @@ square_footage_slider =  html.Label([
     min=df['Living Space'].min(),
     max=df['Living Space'].max(),
     value=[df['Living Space'].min(), df['Living Space'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False})
+    tooltip={'placement': 'bottom', 'always_visible': False}),
+    html.Br()
 ])
 
 price_range_slider =  html.Label([
@@ -50,7 +54,8 @@ price_range_slider =  html.Label([
     min=df['Price'].min(),
     max=df['Price'].max(),
     value=[df['Price'].min(), df['Price'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False})
+    tooltip={'placement': 'bottom', 'always_visible': False}),
+    html.Br()
 ])
 
 price_per_square_footage_range_slider =  html.Label([
@@ -60,7 +65,8 @@ price_per_square_footage_range_slider =  html.Label([
     min=round(df['Price per SqFt'].min(),3),
     max=df['Price per SqFt'].max(),
     value=[round(df['Price per SqFt'].min(),3), df['Price per SqFt'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False})
+    tooltip={'placement': 'bottom', 'always_visible': False}),
+    html.Br()
 ])
 
 home_income_range_slider =  html.Label([
@@ -71,7 +77,8 @@ home_income_range_slider =  html.Label([
     max=df['Median Household Income'].max(),
     value=[df['Median Household Income'].min(), df['Median Household Income'].max()],
     step=90000,
-    tooltip={'placement': 'bottom', 'always_visible': False})
+    tooltip={'placement': 'bottom', 'always_visible': False}),
+    html.Br()
 ])
 
 beds_input =  html.Label([
@@ -95,7 +102,8 @@ beds_input =  html.Label([
             placeholder='Max',
             style={'width': '49%', 'display': 'inline-block', 'float': 'right'}
         )
-    ], style={'padding': '10px 0'})
+    ], style={'padding': '10px 0'}), 
+    html.Br()
 ])
 
 
@@ -120,8 +128,11 @@ baths_input=  html.Label([
             placeholder='Max',
             style={'width': '49%', 'display': 'inline-block', 'float': 'right'}
         )
-    ], style={'padding': '10px 0'})
+    ], style={'padding': '10px 0'}),
+    html.Br()
 ])
+
+clear_all_button = dbc.Button("Reset", id="clear-button", className="mb-3", color="secondary")
 
 city_bar_graph = dcc.Graph(id='city-bar-graph')
 usa_main_map = dcc.Graph(id='usa-map')
@@ -142,8 +153,6 @@ state_abbreviations = {
 # Item associated with mouse clicking function
 state_mapping = {abbr: state for state, abbr in state_abbreviations.items()}
 
-
-
 app.layout = dbc.Container([
     title,
     # Main Row
@@ -158,6 +167,7 @@ app.layout = dbc.Container([
             dbc.Row([home_income_range_slider]),
             dbc.Row([beds_input]),
             dbc.Row([baths_input]),
+            dbc.Row([clear_all_button])
         ], md=2),
         # Second column is for --> Map, bar, and summary Stats
         dbc.Col([
@@ -199,7 +209,6 @@ app.layout = dbc.Container([
         ], style={'textAlign': 'center', 'marginTop': '20px'})
     ])
 ], fluid=True)
-
 
 def generate_us_map():
     fig = px.choropleth(
@@ -271,7 +280,7 @@ def set_cities_options(selected_state):
      Input('beds-min-input', 'value'),
      Input('beds-max-input', 'value'),
      Input('baths-min-input', 'value'),
-     Input('baths-max-input', 'value')])
+     Input('baths-max-input', 'value')],)
 def update_city_bar_graph(state, city, square_footage_range, price_range, ppsf_range, household_income_range, beds_min, beds_max, baths_min, baths_max):
     filtered_df = df.copy()
     
@@ -593,6 +602,31 @@ def update_average_beds(state, city, square_footage_range, price_range, ppsf_ran
     
     return f"Average Beds: {average_beds:.2f}"  
 
+
+#@app.callback(
+#    [Output('state-dropdown', 'value'),
+#     Output('city-dropdown', 'value'),
+#     Output('square-footage-slider', 'value'),
+#     Output('price-range-slider', 'value'),
+#     Output('ppsf-range-slider', 'value'),
+#     Output('hi-range-slider', 'value'),
+#     Output('beds-min-input', 'value'),
+#     Output('beds-max-input', 'value'),
+#     Output('baths-min-input', 'value'),
+#     Output('baths-max-input', 'value')],
+#    [Input('clear-button', 'n_clicks')],
+#    prevent_initial_call=True
+#)
+#def reset_all_filters(n_clicks):
+#    if n_clicks is None or n_clicks < 1:
+#        raise PreventUpdate
+#    return ('All', 'All',
+#            [df['Living Space'].min(), df['Living Space'].max()],
+#            [df['Price'].min(), df['Price'].max()],
+#            [round(df['Price per SqFt'].min(), 3), df['Price per SqFt'].max()],
+#            [df['Median Household Income'].min(), df['Median Household Income'].max()],
+ #           df['Beds'].min(), df['Beds'].max(),
+ #           df['Baths'].min(), df['Baths'].max())
 
 if __name__ == '__main__':
     app.run_server(debug=False)

--- a/src/app.py
+++ b/src/app.py
@@ -76,22 +76,51 @@ home_income_range_slider =  html.Label([
 
 beds_slider =  html.Label([
     "Beds",
-    dcc.RangeSlider(
-    id='beds-slider',
-    min=df['Beds'].min(),
-    max=df['Beds'].max(),
-    value=[df['Beds'].min(), df['Beds'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False})
+    html.Div([
+        dcc.Input(
+            type='number',
+            id='beds-min-input',
+            value=df['Beds'].min(),
+            min=df['Beds'].min(),
+            max=df['Beds'].max(),
+            placeholder='Min',
+            style={'width': '49%', 'display': 'inline-block'}
+        ),
+        dcc.Input(
+            type='number',
+            id='beds-max-input',
+            value=df['Beds'].max(),
+            min=df['Beds'].min(),
+            max=df['Beds'].max(),
+            placeholder='Max',
+            style={'width': '49%', 'display': 'inline-block', 'float': 'right'}
+        )
+    ], style={'padding': '10px 0'})
 ])
+
 
 baths_slider =  html.Label([
     "Baths",
-    dcc.RangeSlider(
-    id='baths-slider',
-    min=df['Baths'].min(),
-    max=df['Baths'].max(),
-    value=[df['Baths'].min(), df['Baths'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False})
+    html.Div([
+        dcc.Input(
+            type='number',
+            id='baths-min-input',
+            value=df['Baths'].min(),
+            min=df['Baths'].min(),
+            max=df['Baths'].max(),
+            placeholder='Min',
+            style={'width': '49%', 'display': 'inline-block'}
+        ),
+        dcc.Input(
+            type='number',
+            id='baths-max-input',
+            value=df['Baths'].max(),
+            min=df['Baths'].min(),
+            max=df['Baths'].max(),
+            placeholder='Max',
+            style={'width': '49%', 'display': 'inline-block', 'float': 'right'}
+        )
+    ], style={'padding': '10px 0'})
 ])
 
 city_bar_graph = dcc.Graph(id='city-bar-graph')
@@ -239,9 +268,11 @@ def set_cities_options(selected_state):
      Input('price-range-slider', 'value'),
      Input('ppsf-range-slider', 'value'),
      Input('hi-range-slider', 'value'),
-     Input('beds-slider', 'value'),
-     Input('baths-slider', 'value')])
-def update_city_bar_graph(state, city, square_footage_range, price_range, ppsf_range, household_income_range, beds, baths):
+     Input('beds-min-input', 'value'),
+     Input('beds-max-input', 'value'),
+     Input('baths-min-input', 'value'),
+     Input('baths-max-input', 'value')])
+def update_city_bar_graph(state, city, square_footage_range, price_range, ppsf_range, household_income_range, beds_min, beds_max, baths_min, baths_max):
     filtered_df = df.copy()
     
     if state != 'All':
@@ -262,11 +293,9 @@ def update_city_bar_graph(state, city, square_footage_range, price_range, ppsf_r
     min_hi, max_hi = household_income_range
     filtered_df = filtered_df[(filtered_df['Median Household Income'] >= min_hi) & (filtered_df['Median Household Income'] <= max_hi)]
     
-    min_beds, max_beds = beds
-    filtered_df = filtered_df[(filtered_df['Beds'] >= min_beds) & (filtered_df['Beds'] <= max_beds)]
+    filtered_df = filtered_df[(filtered_df['Beds'] >= beds_min) & (filtered_df['Beds'] <= beds_max)]
     
-    min_baths, max_baths = baths
-    filtered_df = filtered_df[(filtered_df['Baths'] >= min_baths) & (filtered_df['Baths'] <= max_baths)]
+    filtered_df = filtered_df[(filtered_df['Baths'] >= baths_min) & (filtered_df['Baths'] <= baths_max)]
     
     if not filtered_df.empty:
         city_avg_prices = filtered_df.groupby(['City', 'State'], as_index=False)['Price'].agg(['mean', 'count'])
@@ -304,9 +333,10 @@ def update_city_bar_graph(state, city, square_footage_range, price_range, ppsf_r
      Input('price-range-slider', 'value'),
      Input('ppsf-range-slider', 'value'),
      Input('hi-range-slider', 'value'),
-     Input('beds-slider', 'value'),
-     Input('baths-slider', 'value')]
-)
+     Input('beds-min-input', 'value'),
+     Input('beds-max-input', 'value'),
+     Input('baths-min-input', 'value'),
+     Input('baths-max-input', 'value')])
 def update_median_income_display(state, city, square_footage_range, price_range, ppsf_range, household_income_range, beds, baths):
     # Filter the DataFrame based on the inputs (similar to the bar graph update function)
     filtered_df = df.copy()

--- a/src/app.py
+++ b/src/app.py
@@ -70,6 +70,7 @@ home_income_range_slider =  html.Label([
     min=df['Median Household Income'].min(),
     max=df['Median Household Income'].max(),
     value=[df['Median Household Income'].min(), df['Median Household Income'].max()],
+    step=90000,
     tooltip={'placement': 'bottom', 'always_visible': False})
 ])
 

--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,7 @@ import pandas as pd
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
 
-df = pd.read_csv('/data/processed/processed_df.csv')   
+df = pd.read_csv('data/processed/processed_df.csv')   
 
 title = dbc.Row([dbc.Col(html.H1('Dreamhouse Real Estate Dashboard'), width=12)])
 

--- a/src/app.py
+++ b/src/app.py
@@ -264,7 +264,8 @@ def set_cities_options(selected_state):
     if selected_state == 'All':
         return [{'label': 'All', 'value': 'All'}] + [{'label': city, 'value': city} for city in df['City'].unique()], 'All'
     else:
-        return [{'label': 'All', 'value': 'All'}] + [{'label': city, 'value': city} for city in df[df['State'] == selected_state]['City'].unique()], 'All'
+        cities_in_state = df[df['State'] == selected_state]['City'].unique()
+        return [{'label': 'All', 'value': 'All'}] + [{'label': city, 'value': city} for city in cities_in_state], 'All'
 
 @app.callback(
     Output('city-bar-graph', 'figure'),

--- a/src/app.py
+++ b/src/app.py
@@ -9,71 +9,89 @@ import pandas as pd
 app = dash.Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
 
-df = pd.read_csv('data/processed/processed_df.csv')  
+df = pd.read_csv('../data/processed/processed_df.csv')  
 
 title = dbc.Row([dbc.Col(html.H1('Dreamhouse Real Estate Dashboard'), width=12)])
 
-state_dropdown = dcc.Dropdown(
+state_dropdown = html.Label([
+    "State",
+    dcc.Dropdown(
     id='state-dropdown',
     options=[{'label': 'All', 'value': 'All'}] + [{'label': state, 'value': state} for state in df['State'].unique()],
     value='All',
     clearable=False
-)
+    )
+])
 
-city_dropdown = dcc.Dropdown(
+city_dropdown = html.Label([
+    "City",
+    dcc.Dropdown(
     id='city-dropdown',
     options=[{'label': 'All', 'value': 'All'}],
     value='All',
     clearable=False,
-)
+    )
+])
 
-square_footage_slider = dcc.RangeSlider(
+square_footage_slider =  html.Label([
+    "Square Footage",
+    dcc.RangeSlider(
     id='square-footage-slider',
     min=df['Living Space'].min(),
     max=df['Living Space'].max(),
     value=[df['Living Space'].min(), df['Living Space'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False}
-)
+    tooltip={'placement': 'bottom', 'always_visible': False})
+])
 
-price_range_slider = dcc.RangeSlider(
+price_range_slider =  html.Label([
+    "Price Range",
+    dcc.RangeSlider(
     id='price-range-slider',
     min=df['Price'].min(),
     max=df['Price'].max(),
     value=[df['Price'].min(), df['Price'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False}
-)
+    tooltip={'placement': 'bottom', 'always_visible': False})
+])
 
-price_per_square_footage_range_slider = dcc.RangeSlider(
+price_per_square_footage_range_slider =  html.Label([
+    "Price per Square Footage",
+    dcc.RangeSlider(
     id='ppsf-range-slider',
     min=round(df['Price per SqFt'].min(),3),
     max=df['Price per SqFt'].max(),
     value=[round(df['Price per SqFt'].min(),3), df['Price per SqFt'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False}
-)
+    tooltip={'placement': 'bottom', 'always_visible': False})
+])
 
-home_income_range_slider = dcc.RangeSlider(
+home_income_range_slider =  html.Label([
+    "Median Household Income",
+    dcc.RangeSlider(
     id='hi-range-slider',
     min=df['Median Household Income'].min(),
     max=df['Median Household Income'].max(),
     value=[df['Median Household Income'].min(), df['Median Household Income'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False}
-)
+    tooltip={'placement': 'bottom', 'always_visible': False})
+])
 
-beds_slider = dcc.RangeSlider(
+beds_slider =  html.Label([
+    "Beds",
+    dcc.RangeSlider(
     id='beds-slider',
     min=df['Beds'].min(),
     max=df['Beds'].max(),
     value=[df['Beds'].min(), df['Beds'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False}
-)
+    tooltip={'placement': 'bottom', 'always_visible': False})
+])
 
-baths_slider = dcc.RangeSlider(
+baths_slider =  html.Label([
+    "Baths",
+    dcc.RangeSlider(
     id='baths-slider',
     min=df['Baths'].min(),
     max=df['Baths'].max(),
     value=[df['Baths'].min(), df['Baths'].max()],
-    tooltip={'placement': 'bottom', 'always_visible': False}
-)
+    tooltip={'placement': 'bottom', 'always_visible': False})
+])
 
 city_bar_graph = dcc.Graph(id='city-bar-graph')
 usa_main_map = dcc.Graph(id='usa-map')
@@ -102,29 +120,14 @@ app.layout = dbc.Container([
     dbc.Row([
         # First column --> filters
         dbc.Col([
-            dbc.Label('State'),
-            state_dropdown,
-            html.Br(),
-            dbc.Label('City'),
-            city_dropdown,
-            html.Br(),
-            dbc.Label('Square Footage'),
-            square_footage_slider,
-            html.Br(),
-            dbc.Label('Price Range'),
-            price_range_slider, 
-            html.Br(), 
-            dbc.Label('Price per Square Footage'),
-            price_per_square_footage_range_slider, 
-            html.Br(),
-            dbc.Label('Median Household Income'),
-            home_income_range_slider,
-            html.Br(),
-            dbc.Label('Beds'),
-            beds_slider,
-            html.Br(),
-            dbc.Label('Baths'),
-            baths_slider,
+            dbc.Row([state_dropdown]),
+            dbc.Row([city_dropdown]),
+            dbc.Row([square_footage_slider]),
+            dbc.Row([price_range_slider]),
+            dbc.Row([price_per_square_footage_range_slider]),
+            dbc.Row([home_income_range_slider]),
+            dbc.Row([beds_slider]),
+            dbc.Row([baths_slider]),
         ], md=2),
         # Second column is for --> Map, bar, and summary Stats
         dbc.Col([


### PR DESCRIPTION
In this PR, I've made the following updates:

Filters:
- Format markers for home income
- Format input ranges for filters like beds and baths with default max
   - I updated the use of this filter onto bar graph. This also has to be updated for map and summaries.
- Took the title and html breaks off the app.layout and into the initial definitions of filters
- Fixed the dropdown issue of cities not updating when selection a new state
- fixed another issue with the dropdown issue of cities not showing just the cities within the chosen state

*Attempted to create the reset all to default button, however, whenever i implemented the function/callbacks it would lead to the disappearance of the graphs.

Bar Chart:
- Implemented functionality to display prices by states when the state filter selects all, prices by cities when a specific state is selected, and prices by zip codes when a city filter is applied. The titles of the bar graph and legends dynamically adjust accordingly.
- Adjusted the color scale of the bar chart. Since the default color palettes didn't align with our needs (more states/areas than available colors), I created a custom palette by combining three different default color ranges.
- Ensured that the labels on the y-axis fit neatly beside each bar by fixing the font size and chart dimensions.

*Attempted to address the issue where clicking on a state removes it from the bar graph, but couldn't find a solution. Additionally, I felt that the functionality of selecting per city was adequately covered by the city filter and map click feature.